### PR TITLE
Add improved make.sh map building script.

### DIFF
--- a/lq1/maps/make.sh
+++ b/lq1/maps/make.sh
@@ -1,113 +1,178 @@
-### make commands ###
-function make {
-    cd src-compile/ ;
-    for f in $(find . -name '*.map') ; do qbsp "$f" ; done ;
-    for f in $(find . -name '*.map') ; do vis "$f" ; done ;
-    for f in $(find . -name '*.map') ; do light -extra4 -bounce -dirt "$f" ; done ;
-    cp *.bsp .. ; 
-    cp *.log logs/ ;
-    cp *.lit .. ;
-    rm -f *.log *.bsp *.lit;
-    echo -e "=====Build done=====";
+#
+# LibreQuake Map Builder Shell Script
+# v0.0.2
+# ---
+# MissLavander-LQ & cypress/MotoLegacy
+#
+
+# Map compiler paths
+LQ_QBSP_PATH="qbsp"
+LQ_VIS_PATH="vis"
+LQ_LIG_PATH="light"
+
+# Location of per-map compilation argument paths
+LQ_MAP_CON_PATH="buildconfigs"
+
+# Location of .map source files
+LQ_MAP_SRC_PATH="src-compile"
+
+#
+# DEFAULT COMPILATION FLAGS
+# Always set before config execution to avoid
+# "leaking" into another build.
+#
+LQ_DEF_BSP_FLAGS=""
+LQ_DEF_VIS_FLAGS="-fast"
+LQ_DEF_LIG_FLAGS="-extra4 -bounce -dirt"
+
+#
+# ericw-tools qbsp check
+#
+function check_for_compiler {
+    if [ -z ${LQ_BSP_PATH+x} ]; then
+        # No local path set, is it in $PATH?
+        if ! command -v qbsp &> /dev/null
+        then
+            echo "Couldn't find ericw-tools, required to build map content."
+            echo "Please see https://github.com/ericwa/ericw-tools/ for info."
+            exit
+        fi
+    fi
 }
 
-function -m {
-    cd src-compile/ ;
-    for f in $(find . -name '*.map') ; do qbsp "$f" ; done ;
-    for f in $(find . -name '*.map') ; do vis "$f" ; done ;
-    for f in $(find . -name '*.map') ; do light -extra4 -bounce -dirt "$f" ; done ;
-    cp *.bsp .. ; 
-    cp *.log logs/ ;
-    cp *.lit .. ;
-    rm -f *.log *.bsp *.lit;
-    echo -e "=====Build done=====";
+#
+# MAKE
+#
+
+function setup_compile_args {
+    # Reset our compilation flags
+    LQ_BSP_FLAGS=$LQ_DEF_BSP_FLAGS
+    LQ_VIS_FLAGS=$LQ_DEF_VIS_FLAGS
+    LQ_LIG_FLAGS=$LQ_DEF_LIG_FLAGS
+
+    # Try to source a configuration file
+    source "$LQ_MAP_CON_PATH/$map_name.conf" > /dev/null 2>&1
+
+    # Set force-flags if provided by the user
+    if [ $LQ_FORCED_BSP_FLAGS ]; then
+        LQ_BSP_FLAGS=$LQ_FORCED_BSP_FLAGS
+    fi
+    if [ $LQ_FORCED_VIS_FLAGS ]; then
+        LQ_BSP_FLAGS=$LQ_FORCED_VIS_FLAGS
+    fi
+    if [ $LQ_FORCED_LIG_FLAGS ]; then
+        LQ_BSP_FLAGS=$LQ_FORCED_LIG_FLAGS
+    fi
 }
 
-function -f {
-    cd src-compile/ ;
-    for f in $(find . -name '*.map') ; do qbsp "$f" ; done ;
-    for f in $(find . -name '*.map') ; do vis -fast "$f" ; done ;
-    for f in $(find . -name '*.map') ; do light "$f" ; done ;
-    cp *.bsp .. ;
-    cp *.log logs/ ;
-    cp *.lit .. ;
-    rm -f *.log *.bsp *.lit;
-    echo -e "=====Build done=====";
+function command_make {
+    # Don't bother doing anything if we can't find the compiler
+    check_for_compiler;
+
+    cd "$LQ_MAP_SRC_PATH/"
+
+    # Iterate through every map in our source directory
+    for f in $(find . -name '*.map') ; do
+        # Clean up the string a bit
+        map_name=${f:2:-4}
+        # Get compilation flags ready
+        setup_compile_args;
+        # Perform build operation, silence non-errors
+        echo "- $map_name"
+        $LQ_BSP_PATH "$LQ_BSP_FLAGS $map_name.map" 1> /dev/null
+        $LQ_VIS_PATH "$LQ_VIS_FLAGS $map_name.map" 1> /dev/null
+        $LQ_LIG_PATH "$LQ_LIG_FLAGS $map_name.map" 1> /dev/null
+    done
+
+    cp *.bsp ..
+    cp *.log logs/
+    cp *.lit ..
+    rm -f *.log *.bsp *.lit
+    echo -e "* Build DONE"
 }
 
-### clean commands ###
-function clean {
-    cd src-compile/ ;   
-    rm -f *.prt *.texinfo *.pts;
-    echo -e "=====Cleaning done=====";
+#
+# CLEAN
+#
+
+function command_clean {
+    cd "$LQ_MAP_SRC_PATH/"
+    rm -f *.prt *.texinfo *.pts
+    echo -e "* Clean DONE"
 }
 
-function -c {
-    cd src-compile/ ;   
-    rm -f *.prt *.texinfo *.pts;
-    echo -e "=====Cleaning done=====";
-}
+#
+# HELP
+#
 
-### help commands ###
-function help {
+function command_help {
     echo -e "
+                 LibreQuake make.sh Map Builder Script /// v0.0.2
     ==========================================================================
-    Dependencies [ericw-tools][https://github.com/ericwa/ericw-tools/]
-    run ./make.sh make or -m to compile all maps
-    run ./make.sh clean or -c to remove extra files that are left after build
-    run ./make.sh help or -h to read this msg :3
-    ==========================================================================
-    ";
+    This script requires ericw-tools (https://github.com/ericwa/ericw-tools/).
+    --------------------------------------------------------------------------
+    Usage: make.sh [OPERATION] [FLAGS]
+
+    OPERATIONS:
+    -h, help      read this msg :3
+    -c, clean     remove extra files that are left after build
+    -m, make      compile all available maps
+
+    FLAGS:
+    QBSP_FLAGS    override map-specific qbsp flags with a global setting
+    QBSP_PATH     use a local path for qbsp instead of checking \$PATH
+    VIS_FLAGS     override map-specific vis flags with a global setting
+    VIS_PATH     use a local path for qbsp instead of checking \$PATH
+    LIGHT_FLAGS   override map-specific light flags with a global setting
+    LIGHT_PATH     use a local path for qbsp instead of checking \$PATH
+
+    Example: make.sh -m LIGHT_FLAGS=\"-extra4 -bounce\" QBSP_PATH=\"~/qbsp\"
+    =========================================================================="
 }
 
-function -h {
-    echo -e "
-    ==========================================================================
-    Dependencies [ericw-tools][https://github.com/ericwa/ericw-tools/]
-    run ./make.sh make or -m to compile all maps
-    run ./make.sh clean or -c to remove extra files that are left after build
-    run ./make.sh help or -h to read this msg :3
-    ==========================================================================
-    ";
-}
+#
+# FLAG PARSER
+#
+OIFS=$IFS
+IFS='='
+for arg in "$@"; do
+    # Split argument into flag=val
+    read -r -a flagarg <<< "$arg"
+    flag=${flagarg[0]}
+    val=${flagarg[1]}
 
+    # Parse and store flags.
+    if [ $flag = "QBSP_FLAGS" ]; then
+        LQ_FORCED_BSP_FLAGS=$val
+    elif [ $flag = "QBSP_PATH" ]; then
+        LQ_BSP_PATH=$val
+    elif [ $flag = "VIS_FLAGS" ]; then
+        LQ_FORCED_VIS_FLAGS=$val
+    elif [ $flag = "VIS_PATH" ]; then
+        LQ_VIS_PATH=$val
+    elif [ $flag = "LIGHT_FLAGS" ]; then
+        LQ_FORCED_LIG_FLAGS=$val
+    elif [ $flag = "LIGHT_PATH" ]; then
+        LQ_LIG_PATH=$val
+    fi
+done
+IFS=$OIFS
 
-### command list ###
+#
+# OPERATIONS PARSER
+#
+
 case $1 in
-    make)
-    make
-    ;;
-
-    -m)
-    -m
-    ;;
-
-    -f)
-    -f
-    ;;
-
-    clean)
-    clean
-    ;;
-    
-    -c)
-    -c
-    ;;
-
-    help)
-    help
-    ;;
-
-    -h)
-    -h
-    ;;
-
-    *)
-    echo -e "
-    ====================================
-     run ./make.sh help or ./make.sh -h
-    ====================================
-    "
-    ;;
-    
+    # make/-m : command_make
+    make)command_make;;
+    -m)command_make;;
+    # clean/-c : command_clean
+    clean)command_clean;;
+    -c)command_clean;;
+    # help/-h : command_help
+    help)command_help;;
+    -h)command_help;;
+    # if no command is specified just run help, otherwise
+    # this would be a little annoying.
+    *)command_help;;
 esac

--- a/lq1/maps/src-compile/buildconfigs/start.conf
+++ b/lq1/maps/src-compile/buildconfigs/start.conf
@@ -1,0 +1,3 @@
+LQ_BSP_FLAGS=""
+LQ_VIS_FLAGS="-full"
+LQ_LIG_FLAGS=""


### PR DESCRIPTION
- Add support for map-specific compiler options via `buildconfigs/MAP.conf`.
- Improved help script to provide more detail and provide a version number.
- Add `QBSP_FLAGS`, `LIGHT_FLAGS`, and `VIS_FLAGS` flags for overriding map-specific options, globally.
- Add `QBSP_PATH`, `LIGHT_PATH`, and `VIS_PATH` for specifying locations other than `$PATH` for ericw-tools.
- Check for ericw-tools before trying to compile maps.
- Map compilation will now supress non-warnings, and print out the currently worked on map.
- General cleanup and performance improvements.