### PR TITLE
QC: Add SVC_CUTSCENE-based cameras for use in demo recording

### DIFF
--- a/qcsrc/localization.qc
+++ b/qcsrc/localization.qc
@@ -220,3 +220,14 @@
 #define LOC_TEAMKILL_3	" needs an eye exam"
 #define LOC_TEAMKILL_4	" betrayed their friend"
 #define LOC_TEAMKILL_5	" crushed a teammate"
+
+// Utility Messages
+#define LOC_LQDEVELOPER     "You must be a developer!"
+
+// Cutscene/Demo Camera Messages
+#define LOC_MAXCAMERAS      "You have too many cameras!"
+#define LOC_SPAWNCAMERA_A   "Camera placed successfully, "
+#define LOC_SPAWNCAMERA_B   " remaining"
+#define LOC_CAMERATIME_A    "Time between cameras changed to "
+#define LOC_CAMERATIME_B    " seconds"
+#define LOC_NOCAMERA        "Oh noes! No camera found! :("

--- a/qcsrc/lq1/cutscene_camera.qc
+++ b/qcsrc/lq1/cutscene_camera.qc
@@ -1,0 +1,199 @@
+/*  Copyright (C) 2024 Ivy Bowling <motolegacy@proton.me>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+    See file, 'COPYING', for details.
+*/
+
+#define LQ_MAXCAMERAS   3
+
+float cameras_in_world;
+float clients_at_camera;
+float time_between_cameras;
+
+/*
+============
+LQ_SpawnCamera
+
+============
+*/
+void() LQ_SpawnCamera =
+{
+    if (!cvar("developer")) {
+        bprint(LOC_LQDEVELOPER);
+        bprint("\n");
+        return;
+    }
+
+    if (cameras_in_world >= LQ_MAXCAMERAS) {
+        bprint(LOC_MAXCAMERAS);
+        bprint("\n");
+        return;
+    }
+
+    string camera_targetname;
+    entity camera = spawn();
+    camera.classname = "lq_camera";
+
+    switch(cameras_in_world) {
+        case 0: camera_targetname = "lq_camera_1"; break;
+        case 1: camera_targetname = "lq_camera_2"; break;
+        case 2: camera_targetname = "lq_camera_3"; break;
+    }
+
+    camera.targetname = camera_targetname;
+
+    setorigin(camera, self.origin);
+    camera.angles = self.v_angle;
+
+    cameras_in_world++;
+
+    bprint(LOC_SPAWNCAMERA_A);
+    bprint(ftos(LQ_MAXCAMERAS - cameras_in_world));
+    bprint(LOC_SPAWNCAMERA_B);
+    bprint("\n");
+};
+
+/*
+============
+LQ_AppendCameraTime
+
+============
+*/
+void(float time_addition) LQ_AppendCameraTime = 
+{
+    if (!cvar("developer")) {
+        bprint(LOC_LQDEVELOPER);
+        bprint("\n");
+        return;
+    }
+
+    time_between_cameras += time_addition;
+
+    if (time_between_cameras <= 0)
+        time_between_cameras = 1;
+
+    bprint(LOC_CAMERATIME_A);
+    bprint(ftos(time_between_cameras));
+    bprint(LOC_CAMERATIME_B);
+    bprint("\n");
+};
+
+/*
+============
+LQ_ChangeCamera
+
+============
+*/
+void() LQ_ChangeCamera =
+{
+    // If there's only one camera in the world,
+    // don't bother. Stick here.
+    if (cameras_in_world == 1)
+        return;
+
+    entity camera;
+
+    // Look for second camera if at first
+    if (clients_at_camera == 1) {
+        camera = find(world, targetname, "lq_camera_2");
+        clients_at_camera = 2;
+    } else {
+        // At camera 3, go back to one.
+        if (clients_at_camera == 3) {
+            camera = find(world, targetname, "lq_camera_1");
+            clients_at_camera = 1;
+        }
+        // We're at camera 2, try to find a 3rd
+        if (clients_at_camera == 2) {
+            camera = find(world, targetname, "lq_camera_3");
+            clients_at_camera = 3;
+        }
+        // No dice, only two. go to one.
+        if (camera == world) {
+            camera = find(world, targetname, "lq_camera_1");
+            clients_at_camera = 1;
+        }
+    }
+
+    entity players = find(world, classname, "player");
+
+    while(players != world) {
+        // Plop at the camera
+        setorigin(players, camera.origin);
+        players.angles = players.v_angle = camera.angles;
+
+        // Set up camera change
+        self.nextthink = time + time_between_cameras;
+
+        players = find(players, classname, "player");
+    }
+};
+
+/*
+============
+LQ_PlayCameras
+
+============
+*/
+void() LQ_PlayCameras =
+{
+    if (!cvar("developer")) {
+        bprint(LOC_LQDEVELOPER);
+        bprint("\n");
+        return;
+    }
+
+    entity camera = find(world, targetname, "lq_camera_1");
+
+    if (camera == world) {
+        bprint(LOC_NOCAMERA);
+        bprint("\n");
+        return;
+    }
+
+    // We're at the first camera
+    clients_at_camera = 1;
+
+    // Default time to 1 second
+    if (!time_between_cameras)
+        time_between_cameras = 1;
+
+    // Tell the engine to turn on intermission 3
+    WriteByte (MSG_ALL, SVC_CUTSCENE);
+    WriteString (MSG_ALL, "");  // No message :)
+
+    entity players = find(world, classname, "player");
+
+    while(players != world) {
+        // Make the player static-ish
+        players.view_ofs = '0 0 0';
+        players.fixangle = TRUE;
+        players.takedamage = DAMAGE_NO;
+        players.solid = SOLID_NOT;
+        players.movetype = MOVETYPE_NONE;
+        players.modelindex = 0;
+
+        // Plop them at camera one
+        setorigin(players, camera.origin);
+        players.angles = players.v_angle = camera.angles;
+
+        // Set up camera change
+        camera.think = LQ_ChangeCamera;
+        camera.nextthink = time + time_between_cameras;
+
+        players = find(players, classname, "player");
+    }
+};

--- a/qcsrc/progs.src
+++ b/qcsrc/progs.src
@@ -6,6 +6,9 @@ fight.qc
 ai.qc
 combat.qc
 localization.qc
+
+lq1/cutscene_camera.qc  // LQ: svc_cutscene firing camera
+
 items.qc
 weapons.qc
 world.qc

--- a/qcsrc/weapons.qc
+++ b/qcsrc/weapons.qc
@@ -1307,12 +1307,13 @@ void() QuadCheat =
 	dprint ("quad cheat\n");
 };
 
-/*
-============
-ImpulseCommands
+// LIBREQUAKE START
+#define LQ_IMPULSE_SPAWNCAM		200
+#define LQ_IMPULSE_CAMTIMEINC	201
+#define LQ_IMPULSE_CAMTIMEDEC	202
+#define LQ_IMPULSE_PLAYCAMERAS	203
+// LIBREQUAKE END
 
-============
-*/
 void() ImpulseCommands =
 {
 	if (self.impulse >= 1 && self.impulse <= 8)
@@ -1327,6 +1328,16 @@ void() ImpulseCommands =
 		CycleWeaponReverseCommand();
 	if (self.impulse == 255)
 		QuadCheat ();
+	// LIBREQUAKE START
+	if (self.impulse == LQ_IMPULSE_SPAWNCAM)
+		LQ_SpawnCamera();
+	if (self.impulse == LQ_IMPULSE_CAMTIMEINC)
+		LQ_AppendCameraTime(5);
+	if (self.impulse == LQ_IMPULSE_CAMTIMEDEC)
+		LQ_AppendCameraTime(-5);
+	if (self.impulse == LQ_IMPULSE_PLAYCAMERAS)
+		LQ_PlayCameras();
+	// LIBREQUAKE END
 
 	self.impulse = 0;
 };


### PR DESCRIPTION
Adds the following new impulse commands:
`200` - Spawns a cutscene camera. Maximum of three can be at play. 
`201` - Increments the automatic-switching delay by five seconds. 
`202` - Decrements the automatic-switching delay by five seconds. 
`203` - Begins 'playback' of demo cameras.
`developer 1` must be enabled before use, otherwise `bprint`s are fired reporting you to turn the cvar on.


https://github.com/MissLavender-LQ/LibreQuake/assets/26030250/ea476937-7c80-480a-a751-3e247371402a

