### PR TITLE
QC: Fix call to `__NULL__` in `teleport_use`, move away from `SUB_Null` macro

### DIFF
--- a/build.py
+++ b/build.py
@@ -143,7 +143,7 @@ def compile_bsp():
     os.chdir('../../')
 
 def compile_progs():
-    subprocess.call(['fteqcc', 'qcsrc/progs.src', '-D__LIBREQUAKE__', '-O2'])
+    subprocess.call(['fteqcc', 'qcsrc/progs.src', '-D__LIBREQUAKE__', '-O3'])
 
 def compile():
     compile_wad()

--- a/qcsrc/client.qc
+++ b/qcsrc/client.qc
@@ -352,7 +352,7 @@ void() changelevel_touch =
 		return;
 	}
 
-	self.touch = SUB_Null;
+	self.touch = __NULL__;
 
 	// we can't move people right now, because touch functions are called
 	// in the middle of C movement code, so set a think time to do it

--- a/qcsrc/combat.qc
+++ b/qcsrc/combat.qc
@@ -109,7 +109,7 @@ void(entity targ, entity attacker) Killed =
 	ClientObituary(self, attacker);
 
 	self.takedamage = DAMAGE_NO;
-	self.touch = SUB_Null;
+	self.touch = __NULL__;
 
 	monster_death_use();
 	self.th_die ();

--- a/qcsrc/defs.qc
+++ b/qcsrc/defs.qc
@@ -701,7 +701,6 @@ void(vector destangle, float tspeed, void() func) SUB_CalcAngleMove;
 void()  SUB_CalcMoveDone;
 void() SUB_CalcAngleMoveDone;
 void() SUB_UseTargets;
-#define SUB_Null 		__NULL__
 
 //
 //	combat.qc

--- a/qcsrc/doors.qc
+++ b/qcsrc/doors.qc
@@ -280,10 +280,10 @@ void() door_touch =
 	}
 
 	other.items = other.items - self.items;
-	self.touch = SUB_Null;
+	self.touch = __NULL__;
 
 	if (self.enemy)
-		self.enemy.touch = SUB_Null;	// get paired door
+		self.enemy.touch = __NULL__;	// get paired door
 
 	door_use ();
 };
@@ -624,7 +624,7 @@ void () fd_secret_use =
 	
 	if (!(self.spawnflags & SECRET_NO_SHOOT))
 	{
-		self.th_pain = (void(entity attacker, float damage)) SUB_Null;
+		self.th_pain = __NULL__;
 		self.takedamage = DAMAGE_NO;
 	}
 

--- a/qcsrc/monsters/fiend.qc
+++ b/qcsrc/monsters/fiend.qc
@@ -375,7 +375,7 @@ void()	Demon_JumpTouch =
 	{
 		if (self.flags & FL_ONGROUND)
 		{	// jump randomly to not get hung up
-			self.touch = SUB_Null;
+			self.touch = __NULL__;
 			self.think = demon1_jump1;
 			self.nextthink = time + 0.1;
 		}
@@ -383,7 +383,7 @@ void()	Demon_JumpTouch =
 		return;	// not on ground yet
 	}
 
-	self.touch = SUB_Null;
+	self.touch = __NULL__;
 	self.think = demon1_jump11;
 	self.nextthink = time + 0.1;
 };

--- a/qcsrc/monsters/ogre.qc
+++ b/qcsrc/monsters/ogre.qc
@@ -80,7 +80,7 @@ void() OgreGrenadeExplode =
 	WriteCoord (MSG_BROADCAST, self.origin_z);
 
 	self.velocity = '0 0 0';
-	self.touch = SUB_Null;
+	self.touch = __NULL__;
 	setmodel (self, "progs/s_explod.spr");
 	self.solid = SOLID_NOT;
 	s_explode1 ();

--- a/qcsrc/monsters/rottweiler.qc
+++ b/qcsrc/monsters/rottweiler.qc
@@ -102,7 +102,7 @@ void()	Dog_JumpTouch =
 	{
 		if (self.flags & FL_ONGROUND)
 		{	// jump randomly to not get hung up
-			self.touch = SUB_Null;
+			self.touch = __NULL__;
 			self.think = dog_leap1;
 			self.nextthink = time + 0.1;
 		}
@@ -110,7 +110,7 @@ void()	Dog_JumpTouch =
 		return;	// not on ground yet
 	}
 
-	self.touch = SUB_Null;
+	self.touch = __NULL__;
 	self.think = dog_run1;
 	self.nextthink = time + 0.1;
 };

--- a/qcsrc/monsters/shub.qc
+++ b/qcsrc/monsters/shub.qc
@@ -307,7 +307,7 @@ void() monster_oldone =
 	self.think = old_idle1;
 	self.nextthink = time + 0.1;	
 	self.takedamage = DAMAGE_YES;
-	self.th_pain = (void(entity attacker, float damage)) SUB_Null;
+	self.th_pain = __NULL__;
 	self.th_die = finale_1;
 	shub = self;
 	

--- a/qcsrc/monsters/spawn.qc
+++ b/qcsrc/monsters/spawn.qc
@@ -133,7 +133,7 @@ void()	Tar_JumpTouch =
 	{
 		if (self.flags & FL_ONGROUND)
 		{	// jump randomly to not get hung up
-			self.touch = SUB_Null;
+			self.touch = __NULL__;
 			self.think = tbaby_run1;
 			self.movetype = MOVETYPE_STEP;
 			self.nextthink = time + 0.1;
@@ -142,7 +142,7 @@ void()	Tar_JumpTouch =
 		return;	// not on ground yet
 	}
 
-	self.touch = SUB_Null;
+	self.touch = __NULL__;
 	self.think = tbaby_jump1;
 	self.nextthink = time + 0.1;
 };

--- a/qcsrc/monsters/vore.qc
+++ b/qcsrc/monsters/vore.qc
@@ -227,7 +227,7 @@ void() ShalMissileTouch =
 	WriteCoord (MSG_BROADCAST, self.origin_z);
 
 	self.velocity = '0 0 0';
-	self.touch = SUB_Null;
+	self.touch = __NULL__;
 	setmodel (self, "progs/s_explod.spr");
 	self.solid = SOLID_NOT;
 	s_explode1 ();

--- a/qcsrc/plats.qc
+++ b/qcsrc/plats.qc
@@ -147,7 +147,7 @@ void() plat_crush =
 
 void() plat_use =
 {
-	self.use = SUB_Null;
+	self.use = __NULL__;
 
 	if (self.state != STATE_UP)
 		objerror ("plat_use: not in up state");

--- a/qcsrc/progs.src
+++ b/qcsrc/progs.src
@@ -1,4 +1,4 @@
-../lq1/progs.dat
+progs.dat
 
 defs.qc
 subs.qc

--- a/qcsrc/progs.src
+++ b/qcsrc/progs.src
@@ -1,4 +1,4 @@
-progs.dat
+../lq1/progs.dat
 
 defs.qc
 subs.qc

--- a/qcsrc/subs.qc
+++ b/qcsrc/subs.qc
@@ -18,6 +18,7 @@
 */
 
 void() SUB_Remove = {remove(self);};
+void() SUB_Null = {};
 
 
 /*QuakeEd only writes a single float for angles (bad idea), so up and down are

--- a/qcsrc/subs.qc
+++ b/qcsrc/subs.qc
@@ -298,11 +298,9 @@ void() SUB_UseTargets =
 			self = t;
 			other = stemp;
 
-			if (self.use != SUB_Null)
-			{
-				if (self.use)
-					self.use ();
-			}
+			if (self.use != __NULL__)
+				self.use ();
+
 			self = stemp;
 			other = otemp;
 			activator = act;

--- a/qcsrc/triggers.qc
+++ b/qcsrc/triggers.qc
@@ -79,7 +79,7 @@ void() multi_trigger =
 	else
 	{	// we can't just remove (self) here, because this is a touch function
 		// called wheil C code is looping through area links...
-		self.touch = SUB_Null;
+		self.touch = __NULL__;
 		self.nextthink = time + 0.1;
 		self.think = SUB_Remove;
 	}
@@ -481,7 +481,8 @@ void() teleport_use =
 {
 	self.nextthink = time + 0.2;
 	force_retouch = 2;		// make sure even still objects get hit
-	self.think = SUB_Null;
+	self.think = __NULL__;
+	self.nextthink = 0; // cypress (08 feb 2024) -- engine doesnt guard against NULL think
 };
 
 /*QUAKED trigger_teleport (.5 .5 .5) ? PLAYER_ONLY SILENT
@@ -494,12 +495,12 @@ void() trigger_teleport =
 	local vector o;
 
 	InitTrigger ();
-	self.touch = teleport_touch;
+	self.touch = teleport_use;
 
 	// find the destination
 	if (!self.target)
 		objerror ("no target");
-	self.use = teleport_use;
+	//self.use = teleport_use;
 
 	if (!(self.spawnflags & SILENT))
 	{

--- a/qcsrc/triggers.qc
+++ b/qcsrc/triggers.qc
@@ -495,12 +495,12 @@ void() trigger_teleport =
 	local vector o;
 
 	InitTrigger ();
-	self.touch = teleport_use;
+	self.touch = teleport_touch;
 
 	// find the destination
 	if (!self.target)
 		objerror ("no target");
-	//self.use = teleport_use;
+	self.use = teleport_use;
 
 	if (!(self.spawnflags & SILENT))
 	{

--- a/qcsrc/triggers.qc
+++ b/qcsrc/triggers.qc
@@ -481,8 +481,7 @@ void() teleport_use =
 {
 	self.nextthink = time + 0.2;
 	force_retouch = 2;		// make sure even still objects get hit
-	self.think = __NULL__;
-	self.nextthink = 0; // cypress (08 feb 2024) -- engine doesnt guard against NULL think
+	self.think = SUB_Null;	// cypress (11 feb 2024) -- SUB_Null required to still be present to delay and apply retouch.
 };
 
 /*QUAKED trigger_teleport (.5 .5 .5) ? PLAYER_ONLY SILENT

--- a/qcsrc/weapons.qc
+++ b/qcsrc/weapons.qc
@@ -338,7 +338,7 @@ void() BecomeExplosion =
 {
 	self.movetype = MOVETYPE_NONE;
 	self.velocity = '0 0 0';
-	self.touch = SUB_Null;
+	self.touch = __NULL__;
 	setmodel (self, "progs/s_explod.spr");
 	self.solid = SOLID_NOT;
 	s_explode1 ();


### PR DESCRIPTION
Fixes behaviors when non-clients interact with `trigger_teleport` via `.use` causing execution of `__NULL__`. Also replaces all references of the `SUB_Null `-> `__NULL__` macro with `__NULL__` outright, suggested to mitigate confusion.

Also opts into building with `-O3`, verified that optimizations only cause issues when compiling mutators, which LibreQuake is not.