### PR TITLE
compile_wads.py: Add missing lq_palette

### DIFF
--- a/texture-wads/compile_wads.py
+++ b/texture-wads/compile_wads.py
@@ -12,6 +12,7 @@ def make():
         'lq_liquidsky',
         'lq_mayan',
         'lq_medieval',
+        'lq_palette',
         'lq_metal',
         'lq_props',
         'lq_tech',


### PR DESCRIPTION
build.py calls compile_wads.py - and that one needs to also compile the new lq_palette.wad