### PR TITLE
Add a minimal CI workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+exclude = venv,docs/.etherpad-backups

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,19 @@
+name: flake8
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.11
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+    - name: Analysing the code with flake8
+      run: flake8

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ autosave/
 lq1/screenshots/
 working/
 releases/
+venv/
 
 # ignored files
 docs/lqlogos/logomockup-wip2.ora

--- a/bin/py/asset_analyze.py
+++ b/bin/py/asset_analyze.py
@@ -8,61 +8,65 @@ Script written by ZungryWare
 import sys
 
 console = 1
-#Green text
+# Green text
 if console == 1:
-	col = '\033[92m'
-	end = '\033[0m'
+    col = '\033[92m'
+    end = '\033[0m'
 else:
-	col = "**"
-	end = "**"
+    col = "**"
+    end = "**"
+
 
 def bold(str_in):
-	return col + str(str_in) + end
+    return col + str(str_in) + end
+
 
 def bprint(s):
-	sys.stdout.write(s)
+    sys.stdout.write(s)
+
 
 def main():
-	print(bold("LibreQuake Asset report:\n"))
-	
-	count_total = 0
-	count_complete = 0
-	
-	#Go through the file, listing incomplete items
-	print(bold("Items that still need to be accounted for:"))
-	file1 = open("assets.txt","r")
-	#Go through each line
-	for line in file1:
-		#Only read lines that contain a file
-		if line[:3] == "pak" or line[:3] == "mus":
-			#Track the total number of items
-			count_total += 1
-			items = line.split(" - ")
-			#Ensure there is a name on the list
-			if len(items) == 1:
-				bprint(items[0])
-			elif len(items) >= 2:
-				if items[1] == "\n":
-					bprint(items[0])
-	file1.close()
-	
-	#Go through the file again, listing complete items
-	print(bold("\nItems that are complete or in progress:"))
-	
-	file1 = open("assets.txt","r")
-	for line in file1:
-		if line[:3] == "pak" or line[:3] == "mus":
-			items = line.split(" - ")
-			#Ensure there is not a name on the list
-			if len(items) >= 2:
-				if items[1] != "\n":
-					#Track the total number of COMPLETED items
-					count_complete += 1
-					bprint(bold(items[0]) + " is being accounted for by " + bold(items[1]))
-	file1.close()
-	print("\nItems accounted for: " + bold(str(count_complete) + "/" + str(count_total)))
-	percent = (1.0*count_complete/count_total)*100
-	percent_truncate = int(percent * 1000) / 1000.0
-	print("We're " + bold(str(percent_truncate) + "%") + " of the way there!")
-	
+    print(bold("LibreQuake Asset report:\n"))
+
+    count_total = 0
+    count_complete = 0
+
+    # Go through the file, listing incomplete items
+    print(bold("Items that still need to be accounted for:"))
+    file1 = open("assets.txt", "r")
+    # Go through each line
+    for line in file1:
+        # Only read lines that contain a file
+        if line[:3] == "pak" or line[:3] == "mus":
+            # Track the total number of items
+            count_total += 1
+            items = line.split(" - ")
+            # Ensure there is a name on the list
+            if len(items) == 1:
+                bprint(items[0])
+            elif len(items) >= 2:
+                if items[1] == "\n":
+                    bprint(items[0])
+    file1.close()
+
+    # Go through the file again, listing complete items
+    print(bold("\nItems that are complete or in progress:"))
+
+    file1 = open("assets.txt", "r")
+    for line in file1:
+        if line[:3] == "pak" or line[:3] == "mus":
+            items = line.split(" - ")
+            # Ensure there is not a name on the list
+            if len(items) >= 2:
+                if items[1] != "\n":
+                    # Track the total number of COMPLETED items
+                    count_complete += 1
+                    bprint(bold(items[0]) + " is being accounted for by " + bold(items[1]))
+    file1.close()
+    print("\nItems accounted for: " + bold(str(count_complete) + "/" + str(count_total)))
+    percent = (1.0*count_complete/count_total)*100
+    percent_truncate = int(percent * 1000) / 1000.0
+    print("We're " + bold(str(percent_truncate) + "%") + " of the way there!")
+
+
 main()

--- a/bin/py/quake16x.py
+++ b/bin/py/quake16x.py
@@ -1,42 +1,40 @@
 
-import os, sys
+import os
 from PIL import Image
-import pdb
 
-base_folder = os.path.abspath(os.path.dirname(__file__)).replace("\\","/")
+base_folder = os.path.abspath(os.path.dirname(__file__)).replace("\\", "/")
 converted_folder = base_folder+"/converted/"
 if not os.path.exists(converted_folder):
-	os.makedirs(converted_folder)
+    os.makedirs(converted_folder)
 
 files = os.listdir(base_folder)
 
 converted = 0
 for name in files:
-	try:
-		img = Image.open(name)
-	except (PermissionError, OSError):
-		## skip anything that can't be opened or isn't an image
-		continue
+    try:
+        img = Image.open(name)
+    except (PermissionError, OSError):
+        # skip anything that can't be opened or isn't an image
+        continue
 
-	output_file = converted_folder + name
-	
-	if not img.width % 16 == 0:
-		new_width  = img.width  - (img.width % 16) + 16
-		
-	else: 
-		new_width = img.width
-		
-	if not img.height % 16 == 0:
-		new_height = img.height - (img.height % 16) + 16
-		
-	else: new_height = img.height
-		
+    output_file = converted_folder + name
 
-	print(f"Converting: ({img.width}x{img.height}) -> ({new_width}x{new_height}) - {output_file}");
-		
-	resized = img.resize((new_width, new_height), Image.NEAREST)
-	resized.save(output_file)
-	converted += 1
+    if not img.width % 16 == 0:
+        new_width = img.width - (img.width % 16) + 16
+
+    else:
+        new_width = img.width
+
+    if not img.height % 16 == 0:
+        new_height = img.height - (img.height % 16) + 16
+    else:
+        new_height = img.height
+
+    print(f"Converting: ({img.width}x{img.height}) -> ({new_width}x{new_height}) - {output_file}")
+
+    resized = img.resize((new_width, new_height), Image.NEAREST)
+    resized.save(output_file)
+    converted += 1
 
 plural = "" if converted == 1 else "s"
 print(f"Total: {converted} image{plural} converted.")

--- a/build.py
+++ b/build.py
@@ -19,17 +19,19 @@ import runpy
 import glob
 import argparse
 
+
 # Builds a single file
 def build_file(source_path, destination_path, source_if_missing):
     print(source_path)
     os.makedirs(os.path.dirname(destination_path), exist_ok=True)
     try:
         shutil.copy(source_path, destination_path)
-    except:
+    except Exception:
         if len(source_if_missing):
             shutil.copy(source_if_missing, destination_path)
         else:
             warnings.warn(f"Missing file with no substitute: {source_path}")
+
 
 # Gets a source and dest path from a file entry File. Entries can be a string
 # (where source and dest are the same) or a 2-long list (specifying the source
@@ -39,6 +41,7 @@ def extract_file(file):
         return file[0], file[1]
     else:
         return file, file
+
 
 # Builds a single component from build_components.json
 def build_component(component_data):
@@ -73,6 +76,7 @@ def build_component(component_data):
             source_if_missing,
         )
 
+
 # Build a single release from build_releases.json
 def build_release(name, data):
     # Print
@@ -82,7 +86,7 @@ def build_release(name, data):
     clear_working()
 
     # Create release directory
-    os.makedirs(f'releases', exist_ok=True)
+    os.makedirs('releases', exist_ok=True)
 
     # Pull out base directory
     base_dir = data['base_dir']
@@ -108,7 +112,6 @@ def build_release(name, data):
         os.chdir('../../')
         shutil.copy('working/pak0.pak', os.path.join('releases', name, base_dir, 'pak0.pak'))
 
-
     # Build and copy pak1
     pak1_exists = len(os.listdir('working/pak1')) > 0
     if pak1_exists:
@@ -121,34 +124,40 @@ def build_release(name, data):
         os.chdir('../../')
         shutil.copy('working/pak1.pak', os.path.join('releases', name, base_dir, 'pak1.pak'))
 
+
 # Clears the working directory and sets up empty directories
 def clear_working():
     # Remove working folder and its contents
     shutil.rmtree('./working', ignore_errors=True)
 
     # Create new empty directories
-    os.makedirs(f'working', exist_ok=True)
-    os.makedirs(f'working/pak0', exist_ok=True)
-    os.makedirs(f'working/pak1', exist_ok=True)
-    os.makedirs(f'working/unpacked', exist_ok=True)
+    os.makedirs('working', exist_ok=True)
+    os.makedirs('working/pak0', exist_ok=True)
+    os.makedirs('working/pak1', exist_ok=True)
+    os.makedirs('working/unpacked', exist_ok=True)
+
 
 def compile_wad():
     os.chdir('texture-wads')
     runpy.run_path('./compile_wads.py', run_name="__build__")
     os.chdir('../')
 
+
 def compile_bsp():
     os.chdir('./lq1/maps')
     runpy.run_path('./compile_maps.py', run_name="__build__")
     os.chdir('../../')
 
+
 def compile_progs():
     subprocess.call(['fteqcc', 'qcsrc/progs.src', '-D__LIBREQUAKE__', '-O3'])
+
 
 def compile():
     compile_wad()
     compile_bsp()
     compile_progs()
+
 
 def build():
     # Delete existing releases
@@ -159,6 +168,7 @@ def build():
         releases = json.load(json_file)
         for key, value in releases.items():
             build_release(key, value)
+
 
 def main():
     # Parse command-line arguments
@@ -194,6 +204,7 @@ def main():
 
     # Confirmation
     print("Build complete!")
+
 
 if __name__ == "__main__":
     main()

--- a/lq1/maps/compile_maps.py
+++ b/lq1/maps/compile_maps.py
@@ -25,6 +25,7 @@ LQ_DEF_BSP_FLAGS = ""
 LQ_DEF_VIS_FLAGS = ""
 LQ_DEF_LIG_FLAGS = "-bounce -dirt"
 
+
 # Check for compiler
 def check_for_compiler():
     if not LQ_BSP_PATH:
@@ -32,6 +33,7 @@ def check_for_compiler():
             print("Couldn't find ericw-tools, required to build map content.")
             print("Please see https://github.com/ericwa/ericw-tools/ for info.")
             sys.exit()
+
 
 # Setup compile arguments
 def setup_compile_args(path):
@@ -51,6 +53,7 @@ def setup_compile_args(path):
                 if line.startswith("LQ_LIG_FLAGS"):
                     LQ_LIG_FLAGS = line.split("\"")[1]
 
+
 # Execute command
 def execute_command(command):
     process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -59,14 +62,16 @@ def execute_command(command):
         if "WARNING" in line or "Leak" in line:
             print(line)
 
+
 # Find all files in directory with this extension
 def find(directory, ext):
-    l = []
+    result_list = []
     for root, dirs, files in os.walk(directory):
         for file in files:
             if file.endswith(ext):
-                l.append(os.path.join(root, file))
-    return l
+                result_list.append(os.path.join(root, file))
+    return result_list
+
 
 def move_file(src, dest_dir):
     # Get the base filename
@@ -81,6 +86,7 @@ def move_file(src, dest_dir):
 
     # Move the source file to the destination directory
     shutil.move(src, dest_file)
+
 
 # Command make
 def command_make(specific_map=None):
@@ -103,9 +109,12 @@ def command_make(specific_map=None):
         setup_compile_args(f)
         print(f"- {f}")
         devnull = open(os.devnull, 'w')
-        subprocess.call([LQ_BSP_PATH] + LQ_BSP_FLAGS.split() + [f"{map_name}.map"], stdout=devnull, cwd=os.path.dirname(f))
-        subprocess.call([LQ_VIS_PATH] + LQ_VIS_FLAGS.split() + [f"{map_name}.bsp"], stdout=devnull, cwd=os.path.dirname(f))
-        subprocess.call([LQ_LIG_PATH] + LQ_LIG_FLAGS.split() + [f"{map_name}.bsp"], stdout=devnull, cwd=os.path.dirname(f))
+        subprocess.call([LQ_BSP_PATH] + LQ_BSP_FLAGS.split() + [f"{map_name}.map"],
+                        stdout=devnull, cwd=os.path.dirname(f))
+        subprocess.call([LQ_VIS_PATH] + LQ_VIS_FLAGS.split() + [f"{map_name}.bsp"],
+                        stdout=devnull, cwd=os.path.dirname(f))
+        subprocess.call([LQ_LIG_PATH] + LQ_LIG_FLAGS.split() + [f"{map_name}.bsp"],
+                        stdout=devnull, cwd=os.path.dirname(f))
 
     # Move bsp and lit files into the /lq1/maps directory
     print("Moving files...")
@@ -115,6 +124,7 @@ def command_make(specific_map=None):
 
     print("* Build DONE")
 
+
 # Command single
 def command_single(map_name):
     if not map_name:
@@ -122,12 +132,14 @@ def command_single(map_name):
         return
     command_make(map_name)
 
+
 # Command clean
 def command_clean():
     for ext in [".bsp", ".lit", ".prt", ".texinfo", ".texinfo.json", ".pts", ".log"]:
         for file in find('./', ext):
             os.remove(file)
     print("* Clean DONE")
+
 
 # Command help
 def command_help():
@@ -146,17 +158,18 @@ def command_help():
 
     FLAGS:
     QBSP_FLAGS    override map-specific qbsp flags with a global setting
-    QBSP_PATH     use a local path for qbsp instead of checking \$PATH
+    QBSP_PATH     use a local path for qbsp instead of checking $PATH
     VIS_FLAGS     override map-specific vis flags with a global setting
-    VIS_PATH     use a local path for qbsp instead of checking \$PATH
+    VIS_PATH     use a local path for qbsp instead of checking $PATH
     LIGHT_FLAGS   override map-specific light flags with a global setting
-    LIGHT_PATH     use a local path for qbsp instead of checking \$PATH
+    LIGHT_PATH     use a local path for qbsp instead of checking $PATH
 
     Example: make.py -m LIGHT_FLAGS=\"-extra4 -bounce\" QBSP_PATH=\"~/qbsp\"
     Example: make.py -s e1/e1m1
     ==========================================================================
     """
     print(help_text)
+
 
 # Argument parsing
 def parse_args(args):
@@ -169,6 +182,7 @@ def parse_args(args):
 
     operation = operations.get(args[0], command_help)
     operation()
+
 
 # If being run from the command line
 if __name__ == "__main__":

--- a/texture-wads/compile_wads.py
+++ b/texture-wads/compile_wads.py
@@ -1,6 +1,7 @@
 import subprocess
 import glob
 
+
 def make():
     wads_list = [
         'lq_dev',
@@ -25,6 +26,7 @@ def make():
         command.extend(filepaths)
         command.extend(['-o', f'{wad}.wad'])
         subprocess.call(command)
+
 
 if __name__ == "__main__":
     make()


### PR DESCRIPTION
This change adds a tiny CI workflow to keep the python files clean.
I made the initial changes to the py files which mostly was inconsistent whitespaces and some minor issues.

The pipelines runs only on pull requests at moment and in the future could be expanded to check that your usual release build workflows runs without issues.

PS: I have excluded docs/.etherpad-backups from the checks since I assume this is an unmaintained file.
Also since github actions haven't been configured for this repository before the CI run won't be triggered due to security but should run on the next PR.