### PR TITLE
QC: Enhance Intermission+Epilogue Implementation, Add Episode 0 Epilogue.

### DIFF
--- a/qcsrc/client.qc
+++ b/qcsrc/client.qc
@@ -171,6 +171,21 @@ void() GotoNextMap =
 		changelevel (nextmap);
 };
 
+// cypress (09 mar 2024) -- use struct for epilogue levels.
+var struct
+{
+	string 	map_name;
+	float	cd_track;
+	string 	epilogue_text;
+	string 	freeware_text;
+} intermission_levels[] =
+{
+	{"maps/e1m7.bsp", 2, LOC_EPILOGUE_1, LOC_EPILOGUE_1_FREEWARE},
+	{"maps/e2m6.bsp", 2, LOC_EPILOGUE_2, __NULL__},
+	{"maps/e3m6.bsp", 2, LOC_EPILOGUE_3, __NULL__},
+	{"maps/e4m7.bsp", 2, LOC_EPILOGUE_4, __NULL__}
+};
+// --cypress
 
 void() ExitIntermission =
 {
@@ -189,62 +204,29 @@ void() ExitIntermission =
 //
 	if (intermission_running == 2)
 	{
-		if (world.model == "maps/e1m7.bsp")
+		// cypress (09 mar 2024) -- use struct for epilogue levels.
+		for (float i = 0; i < intermission_levels.length; i++)
 		{
-			WriteByte (MSG_ALL, SVC_CDTRACK);
-			WriteByte (MSG_ALL, 2);
-			WriteByte (MSG_ALL, 3);
-
-			if (!cvar("registered"))
+			if (world.model == intermission_levels[i].map_name)
 			{
-				WriteByte (MSG_ALL, SVC_FINALE);
-				WriteString (MSG_ALL, LOC_EPILOGUE_1_FREEWARE);
+				WriteByte (MSG_ALL, SVC_CDTRACK);
+				WriteByte (MSG_ALL, intermission_levels[i].cd_track);	// [cdtrack]
+				WriteByte (MSG_ALL, 3);									// [looptrack], unused.
+
+				WriteByte(MSG_ALL, SVC_FINALE);
+
+				if (!cvar("registered") && intermission_levels[i].freeware_text != __NULL__)
+				{
+					WriteString(MSG_ALL, intermission_levels[i].freeware_text);
+				}
+				else
+				{
+					WriteString(MSG_ALL, intermission_levels[i].epilogue_text);
+				}
+				return;
 			}
-
-			else
-			{
-				WriteByte (MSG_ALL, SVC_FINALE);
-				WriteString (MSG_ALL, LOC_EPILOGUE_1);
-			}
-
-			return;
 		}
-
-		else if (world.model == "maps/e2m6.bsp")
-		{
-			WriteByte (MSG_ALL, SVC_CDTRACK);
-			WriteByte (MSG_ALL, 2);
-			WriteByte (MSG_ALL, 3);
-
-			WriteByte (MSG_ALL, SVC_FINALE);
-			WriteString (MSG_ALL, LOC_EPILOGUE_2);
-
-			return;
-		}
-
-		else if (world.model == "maps/e3m6.bsp")
-		{
-			WriteByte (MSG_ALL, SVC_CDTRACK);
-			WriteByte (MSG_ALL, 2);
-			WriteByte (MSG_ALL, 3);
-
-			WriteByte (MSG_ALL, SVC_FINALE);
-			WriteString (MSG_ALL, LOC_EPILOGUE_3);
-
-			return;
-		}
-
-		else if (world.model == "maps/e4m7.bsp")
-		{
-			WriteByte (MSG_ALL, SVC_CDTRACK);
-			WriteByte (MSG_ALL, 2);
-			WriteByte (MSG_ALL, 3);
-
-			WriteByte (MSG_ALL, SVC_FINALE);
-			WriteString (MSG_ALL, LOC_EPILOGUE_4);
-
-			return;
-		}
+		// --cypress
 
 		GotoNextMap();
 	}
@@ -1314,7 +1296,13 @@ called when a player dies
 void(entity targ, entity attacker) ClientObituary =
 {
 	local	float rnum;
+
+#ifdef __LIBREQUAKE__
+
 	local	float rnum2;
+
+#endif // __LIBREQUAKE__
+
 	local	string deathstring, deathstring2;
 	deathstring = deathstring2 = string_null;
 	// From GPL QW source

--- a/qcsrc/client.qc
+++ b/qcsrc/client.qc
@@ -180,6 +180,13 @@ var struct
 	string 	freeware_text;
 } intermission_levels[] =
 {
+
+#ifdef __LIBREQUAKE__
+
+	{"maps/e0m7.bsp", 2, LOC_EPILOGUE_0, __NULL__},
+
+#endif // __LIBREQUAKE__
+
 	{"maps/e1m7.bsp", 2, LOC_EPILOGUE_1, LOC_EPILOGUE_1_FREEWARE},
 	{"maps/e2m6.bsp", 2, LOC_EPILOGUE_2, __NULL__},
 	{"maps/e3m6.bsp", 2, LOC_EPILOGUE_3, __NULL__},

--- a/qcsrc/localized_text.qc
+++ b/qcsrc/localized_text.qc
@@ -29,11 +29,14 @@
 
 			EPISODE EPILOGUE STRINGS
 
+        These strings in-engine have a 40 character limit before
+        truncation.
+
 ==============================================================================*/
 
 #ifdef __LIBREQUAKE__
 
-#define LOC_EPILOGUE_0              "\nAs the ethereal essence of your very\nbeing drifts through time and space,\nyou experience relentless calm and\nserene determination. You embrace the\nliminal, formless nature of your existence\nwithin the amorphous expanse between\nrealities.\n\nSuspended between the veils of life\nand death, among the realm of celestial\ndissolution, you wait to be called upon\nagain. To regain your corporeal form\nand step into the crucible of fate.\nTo finish your task and keep at bay the\nonslaught of cosmic horrors.\n"
+#define LOC_EPILOGUE_0              "\nAs the ethereal essence of your very\nbeing drifts through time and space,\nyou experience relentless calm and\nserene determination. You embrace the\nliminal, formless nature of your\nexistence within the amorphous expanse\nbetween realities.\n\nSuspended between the veils of life\nand death, among the realm of celestial\ndissolution, you wait to be called upon\nagain. To regain your corporeal form\nand step into the crucible of fate.\nTo finish your task and keep at bay the\nonslaught of cosmic horrors.\n"
 #define LOC_EPILOGUE_1              "EPISODE 1 COMPLETION TEXT GOES HERE"
 #define LOC_EPILOGUE_1_FREEWARE     "EPISODE 1 COMPLETION TEXT GOES HERE"
 #define LOC_EPILOGUE_2              "EPISODE 2 COMPLETION TEXT GOES HERE"

--- a/qcsrc/localized_text.qc
+++ b/qcsrc/localized_text.qc
@@ -33,7 +33,7 @@
 
 #ifdef __LIBREQUAKE__
 
-#define LOC_EPILOGUE_0              "\nAs the ethereal essence of your very\nbeing drifts through time and space,\nyou experience relentless calm and\nserene determination. You embrace the\nliminal, formless nature of your being\nwithin the amorphous expanse between\nrealities.\n\nSuspended between the veils of life\nand death, among the realm of celestial\ndissolution, you wait to be called upon\nagain. To regain your corporeal form\nand step into the crucible of fate.\nTo finish your task and keep at bay the\nonslaught of cosmic horrors.\n"
+#define LOC_EPILOGUE_0              "\nAs the ethereal essence of your very\nbeing drifts through time and space,\nyou experience relentless calm and\nserene determination. You embrace the\nliminal, formless nature of your existence\nwithin the amorphous expanse between\nrealities.\n\nSuspended between the veils of life\nand death, among the realm of celestial\ndissolution, you wait to be called upon\nagain. To regain your corporeal form\nand step into the crucible of fate.\nTo finish your task and keep at bay the\nonslaught of cosmic horrors.\n"
 #define LOC_EPILOGUE_1              "EPISODE 1 COMPLETION TEXT GOES HERE"
 #define LOC_EPILOGUE_1_FREEWARE     "EPISODE 1 COMPLETION TEXT GOES HERE"
 #define LOC_EPILOGUE_2              "EPISODE 2 COMPLETION TEXT GOES HERE"

--- a/qcsrc/localized_text.qc
+++ b/qcsrc/localized_text.qc
@@ -33,6 +33,7 @@
 
 #ifdef __LIBREQUAKE__
 
+#define LOC_EPILOGUE_0              "\nAs the ethereal essence of your very\nbeing drifts through time and space,\nyou experience relentless calm and\nserene determination. You embrace the\nliminal, formless nature of your being\nwithin the amorphous expanse between\nrealities.\n\nSuspended between the veils of life\nand death, among the realm of celestial\ndissolution, you wait to be called upon\nagain. To regain your corporeal form\nand step into the crucible of fate.\nTo finish your task and keep at bay the\nonslaught of cosmic horrors.\n"
 #define LOC_EPILOGUE_1              "EPISODE 1 COMPLETION TEXT GOES HERE"
 #define LOC_EPILOGUE_1_FREEWARE     "EPISODE 1 COMPLETION TEXT GOES HERE"
 #define LOC_EPILOGUE_2              "EPISODE 2 COMPLETION TEXT GOES HERE"


### PR DESCRIPTION
Uses data structures to improve implementation for adding new epilogues to specific maps via QuakeC, as well as allows the developer to specify which CD Track to use. Demonstrates usefulness by 1-lining support for LibreQuake's Episode 0, which fixes #117.