### PR TITLE
Change ci trigger from PR to push

### DIFF
--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -1,9 +1,12 @@
 name: flake8
 
-on: [pull_request]
+on:
+  push:
+    paths:
+      - '**.py'
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
I figured it makes more sense to run this check on pushes containing changes in python files instead of any old PR